### PR TITLE
Feature/fail dashboard

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,7 @@ gem 'nokogiri', '1.8.0'
 gem 'httparty', '0.15.5'
 gem 'cta_aggregator_client', '0.1.0'
 gem 'Indirizzo', '0.1.7'
+gem 'will_paginate', '3.1.6'
 
 group :development, :test do
   gem 'dotenv-rails', '2.2.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -208,6 +208,7 @@ GEM
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
+    will_paginate (3.1.6)
 
 PLATFORMS
   ruby
@@ -233,6 +234,7 @@ DEPENDENCIES
   turbolinks (~> 5)
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
+  will_paginate (= 3.1.6)
 
 RUBY VERSION
    ruby 2.4.0p0

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -12,3 +12,4 @@
 
  @import 'style';
  @import 'authentication';
+ @import 'scrape_fails';

--- a/app/assets/stylesheets/scrape_fails.scss
+++ b/app/assets/stylesheets/scrape_fails.scss
@@ -6,6 +6,12 @@
       text-align: left;
     }
   }
+
+  .pagination-links {
+    display: flex;
+    justify-content: center;
+    margin-top: 3vh;
+  }
 }
 
 .scrape-fail-details {

--- a/app/assets/stylesheets/scrape_fails.scss
+++ b/app/assets/stylesheets/scrape_fails.scss
@@ -1,0 +1,59 @@
+.scrape-fails {
+  table {
+    text-align: center;
+
+    .url {
+      text-align: left;
+    }
+  }
+}
+
+.scrape-fail-details {
+
+  .guide-text-container {
+    margin-top: 5vh;
+  }
+
+  .row {
+    width: 100%;
+    display: flex;
+    justify-content: flex-start;
+    flex-flow: row nowrap;
+    text-align: left;
+    margin-bottom: 3vh;
+
+    .heading {
+      padding-left: 5vw;
+      min-width: 15%;
+      font-weight: bold;
+    }
+  }
+
+  ul {
+    display: flex;
+    flex-flow: column nowrap;
+    padding-left: 0;
+    margin-top: 0;
+    list-style: none;
+
+    li {
+      display: flex;
+      justify-content: flex-start;
+
+      .scrape-attr {
+        font-weight: bold;
+      }
+    }
+
+    .backtrace-line {
+      padding-top: 2vh;
+
+    }
+  }
+
+  .guide-text {
+    font-weight: bold;
+    font-size: 1.5rem;
+  }
+}
+

--- a/app/assets/stylesheets/style.scss
+++ b/app/assets/stylesheets/style.scss
@@ -44,7 +44,6 @@ h1, h2, h3, h4, h5, h6 {
   display: flex;
   flex-flow: column nowrap;
   justify-content: center;
-  text-align:center;
   font-size: 1.5rem;
 }
 
@@ -93,3 +92,19 @@ input[type=submit] {
   cursor: pointer;
   border-radius: 5px;
 }
+
+  .guide-text-container {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin-bottom: 5vh;
+
+    .guide-text {
+      background-color: lightgrey;
+      max-width: 75%;
+      flex-flow: column wrap;
+      border-radius: 2vw;
+      padding: 0 1%;
+      text-align: center;
+    }
+  }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,6 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
   def after_sign_in_path_for(user)
-    dashboards_path
+    scrape_fails_path
   end
 end

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -1,7 +1,0 @@
-class DashboardController < ApplicationController
-  before_action :authenticate_admin!
-
-  def index
-  end
-
-end

--- a/app/controllers/scrape_fails_controller.rb
+++ b/app/controllers/scrape_fails_controller.rb
@@ -2,10 +2,8 @@ class ScrapeFailsController < ApplicationController
   before_action :authenticate_admin!
 
   def index
-    @scrape_fails = ScrapeFail.active
-    #paginage that shit
+    @scrape_fails = ScrapeFail.active.paginate(page: params[:page], per_page: 20)
   end
-
 
   def show
     @scrape_fail = ScrapeFail.find_by_id(params[:id])

--- a/app/controllers/scrape_fails_controller.rb
+++ b/app/controllers/scrape_fails_controller.rb
@@ -1,0 +1,31 @@
+class ScrapeFailsController < ApplicationController
+  before_action :authenticate_admin!
+
+  def index
+    @scrape_fails = ScrapeFail.active
+    #paginage that shit
+  end
+
+
+  def show
+    @scrape_fail = ScrapeFail.find_by_id(params[:id])
+  end
+
+  def update
+    @scrape_fail = ScrapeFail.find_by_id(params[:id])
+    if @scrape_fail.update_attributes(fail_params)
+      flash[:success] = "Success!"
+      redirect_to scrape_fails_path
+    else
+      flash[:error] = "Something went wrong."
+      redirect_to scrape_fails_path
+    end
+  end
+
+  private
+
+  def fail_params
+    params.require(:scrape_fail).permit(:active)
+  end
+
+end

--- a/app/models/scrape_fail.rb
+++ b/app/models/scrape_fail.rb
@@ -1,2 +1,3 @@
 class ScrapeFail < ApplicationRecord
+  scope :active, -> { where(active: true) }
 end

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -1,1 +1,0 @@
-<h1>Dashboard</h1>

--- a/app/views/scrape_fails/index.html.erb
+++ b/app/views/scrape_fails/index.html.erb
@@ -1,0 +1,75 @@
+<h1> Failures </h1>
+
+<div class='guide-text-container'>
+  <div class='guide-text'>
+    <p>
+    The items below represent failed attempts to scrape a website and generate data in the CTAAggregagor API.
+    </p>
+    <p>
+    Once you have fixed the cause of the scraping error, please dismiss the error.  This will perform a soft delete and he record won't appear below anymore.
+    </p>
+  </div>
+</div>
+
+<div class='scrape-fails'>
+
+<table>
+  <tr>
+    <th>
+      Scrape Date
+    </th>
+
+    <th>
+      Status Code
+    </th>
+
+    <th>
+      Message
+    </th>
+  
+    <th>
+      Origin System
+    </th>
+
+    <th>
+      URL
+    </th>
+
+    <th>
+      Actions
+    </th>
+
+  </tr>
+  <% @scrape_fails.each do |scrape_fail| %>
+
+    <tr>
+      <td>
+        <%= scrape_fail.created_at.strftime('%b %d, %Y %l:%M %p') %>
+      </td>
+
+      <td>
+        <%= scrape_fail.status_code %>
+      </td>
+
+      <td>
+        <%= scrape_fail.message %>
+      </td>
+
+      <td>
+        <%= scrape_fail.scrape_attrs['origin_system'] %>
+      </td>
+
+      <td class='url'>
+        <%= scrape_fail.scrape_attrs['browser_url'] %>
+      </td>
+
+      <td>
+        <%= link_to 'View', scrape_fail_path(scrape_fail.id) %>
+        <%= link_to 'Dismiss', scrape_fail_path(scrape_fail.id, scrape_fail: { active: false } ), method: :put, data: {confirm: "Are you sure?"}  %>
+      </td>
+
+    </tr>
+  <% end %>
+</table>
+
+</div>

--- a/app/views/scrape_fails/index.html.erb
+++ b/app/views/scrape_fails/index.html.erb
@@ -6,7 +6,7 @@
     The items below represent failed attempts to scrape a website and generate data in the CTAAggregagor API.
     </p>
     <p>
-    Once you have fixed the cause of the scraping error, please dismiss the error.  This will perform a soft delete and he record won't appear below anymore.
+    Once you have fixed the cause of the scraping error, please dismiss the error.  This will perform a soft delete and the record won't appear below anymore.
     </p>
   </div>
 </div>

--- a/app/views/scrape_fails/index.html.erb
+++ b/app/views/scrape_fails/index.html.erb
@@ -72,4 +72,8 @@
   <% end %>
 </table>
 
+<div class='pagination-links'>
+  <%= will_paginate @scrape_fails %>
+</div>
+
 </div>

--- a/app/views/scrape_fails/show.html.erb
+++ b/app/views/scrape_fails/show.html.erb
@@ -1,0 +1,82 @@
+<div class="scrape-fail-details">
+
+  <div class='guide-text-container'>
+    <div class='guide-text'>
+      <p>
+      This is a brief overview on what went wrong when attempting pull data from
+      a website and send it over the CTA Aggregator API.
+      </p>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="heading">
+      Scrape Date
+    </div>
+
+    <div class="info"> <%= @scrape_fail.created_at.strftime('%b %d, %Y %l:%M %p') %>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="heading">
+      Status Code
+    </div>
+
+    <div class="info">
+      <%= @scrape_fail.status_code %>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="heading">
+      Error Message
+    </div>
+
+    <div class="info">
+      <%= @scrape_fail.message %>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="heading">
+      Partial Backtrace
+    </div>
+
+    <div class="info">
+
+      <ul>
+        <% @scrape_fail.backtrace.each do |line| %>
+          <li class='backtrace-line'>
+            <%= line %>
+          </li>
+        <% end %>
+        <ul>
+
+        <div class='guide-text'>
+          <p>
+          Note: this only represents the first few lines of the backtrace.
+          To get the full backtrace, please reproduce this error locally.
+          </p>
+        </div>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="heading">
+      Scraped Attributes
+    </div>
+
+    <div class="info">
+
+      <ul>
+        <% @scrape_fail.scrape_attrs.each do |k, v | %>
+          <li>
+            <div class='scrape-attr'><%= k %>: &nbsp</div> <%= v %>
+          </li>
+        <% end %>
+      </ul>
+    </div>
+  </div>
+
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,8 @@
 Rails.application.routes.draw do
 
+  resources :scrape_fails, only: [:index, :show, :update]
+
   devise_for :admins
-  get :dashboards, to: 'dashboard#index'
   root to: 'welcome#index'
 
 end

--- a/db/migrate/20170806210022_alter_scrape_fails_add_scrape_attrs_col.rb
+++ b/db/migrate/20170806210022_alter_scrape_fails_add_scrape_attrs_col.rb
@@ -1,0 +1,11 @@
+class AlterScrapeFailsAddScrapeAttrsCol < ActiveRecord::Migration[5.1]
+  def up
+    add_column :scrape_fails, :scrape_attrs, :jsonb, default: {}
+    remove_column :scrape_fails, :event_attrs
+  end
+
+  def down
+    remove_column :scrape_fails, :scrape_attrs
+    add_column :scrape_fails, :event_attrs, :text
+  end
+end

--- a/db/migrate/20170806211134_a_lter_scrape_fail_add_active_col.rb
+++ b/db/migrate/20170806211134_a_lter_scrape_fail_add_active_col.rb
@@ -1,0 +1,5 @@
+class ALterScrapeFailAddActiveCol < ActiveRecord::Migration[5.1]
+  def change
+    add_column :scrape_fails, :active, :boolean, default: true
+  end
+end

--- a/db/migrate/20170807030919_alter_scrape_fail_change_backtrace_data_type.rb
+++ b/db/migrate/20170807030919_alter_scrape_fail_change_backtrace_data_type.rb
@@ -1,0 +1,9 @@
+class AlterScrapeFailChangeBacktraceDataType < ActiveRecord::Migration[5.1]
+  def up
+    change_column :scrape_fails, :backtrace, :text, array: true, default: [], using: "(string_to_array(backtrace, ','))"
+  end
+
+  def down
+    change_column :scrape_fails, :backtrace, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170805033150) do
+ActiveRecord::Schema.define(version: 20170807030919) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -35,10 +35,11 @@ ActiveRecord::Schema.define(version: 20170805033150) do
   create_table "scrape_fails", force: :cascade do |t|
     t.string "status_code"
     t.string "message"
-    t.text "backtrace"
-    t.text "event_attrs"
+    t.text "backtrace", default: [], array: true
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.jsonb "scrape_attrs", default: {}
+    t.boolean "active", default: true
   end
 
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,23 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
-#   Character.create(name: 'Luke', movie: movies.first)
+admin = Admin.find_or_initialize_by(email: 'a@example.com')
+admin.password = 'password123'
+admin.save
+
+ScrapeFail.create!(
+  "status_code"=>"500",
+  "message"=>"500 Internal Server Error",
+  "backtrace"=>
+  ["/Users/goober/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rest-client-2.0.1/lib/restclient/abstract_response.rb:103:in `return!'",
+   "/Users/goober/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rest-client-2.0.1/lib/restclient/request.rb:809:in `process_result'",
+   "/Users/goober/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rest-client-2.0.1/lib/restclient/request.rb:725:in `block in transmit'",
+   "/Users/goober/.rbenv/versions/2.4.0/lib/ruby/2.4.0/net/http.rb:877:in `start'"],
+   "scrape_attrs"=>
+  {"free"=>false,
+   "title"=>
+  "Join EMILY's List President Stephanie Schriock and special guest Congresswoman Jacky Rosen at our 2017 Ignite Change Luncheon in San Francisco!",
+    "location"=>
+  {"region"=>"CA", "locality"=>"San Francisco", "postal_code"=>"94108", "address_lines"=>["The Fairmont Hotel", "950 Mason Street"]},
+    "start_date"=>"2017-10-13T11:00:00.000+00:00",
+    "browser_url"=>"https://secure.emilyslist.org/page/contribute/western-regional-luncheon",
+    "origin_system"=>"Emily's List"},
+    "active"=>true
+)

--- a/lib/scraper/emilys_list.rb
+++ b/lib/scraper/emilys_list.rb
@@ -41,7 +41,7 @@ module Scraper
         status_code: e.http_code,
         message: e.message,
         backtrace: e.backtrace[1..4],
-        event_attrs: event_data
+        scrape_attrs: event_data
       )
     end
 

--- a/lib/scraper/scraper_base.rb
+++ b/lib/scraper/scraper_base.rb
@@ -1,4 +1,4 @@
-require 'Indirizzo'
+require 'indirizzo/address'
 require 'nokogiri'
 require 'httparty'
 require 'cta_aggregator_client'


### PR DESCRIPTION
This PR 
* Adds basic UI for a dashboard showing scraping failures
* Adds ability to see details about how scraping failed
* Allows for a soft delete of a scraping Failure.  I figure that once we see fix a scraping script gone awry, we'll want a way to make sure it doesn't appear again.
* Removes old generic Dashboard view (it was a placeholder)

Dashboard:

![image](https://user-images.githubusercontent.com/769888/29012742-bc5d21d2-7af2-11e7-999f-1e96c522e48d.png)

Detail:

![image](https://user-images.githubusercontent.com/769888/29012756-cce578d8-7af2-11e7-8894-5ff6a657dda3.png)
