### PR TITLE
Feature/5calls

### DIFF
--- a/lib/scraper.rb
+++ b/lib/scraper.rb
@@ -1,4 +1,5 @@
 require 'scraper/emilys_list'
+require 'scraper/five_calls'
 
 module Scraper
   class << self
@@ -7,5 +8,8 @@ module Scraper
       EmilysList.new(ScrapeFail)
     end
 
+    def five_calls
+      FiveCalls.new(ScrapeFail)
+    end
   end
 end

--- a/lib/scraper/emilys_list.rb
+++ b/lib/scraper/emilys_list.rb
@@ -29,12 +29,7 @@ module Scraper
       # We're doing it here because we always want to ensure the scraper can
       # continue iterating through the list of scraped events.
 
-      scrape_fail.create!(
-        status_code: e.http_code,
-        message: e.message,
-        backtrace: e.backtrace[1..4],
-        scrape_attrs: event_data
-      )
+      log_scrape_failure(e, event_data)
     end
 
     def find_or_create_event(event_data)

--- a/lib/scraper/emilys_list.rb
+++ b/lib/scraper/emilys_list.rb
@@ -9,10 +9,6 @@ module Scraper
       'browser_url', 'origin_system', 'title', 'description', 'start_date', 'end_date', 'free', 'featured_image_url'
     ].freeze
 
-    def initialize(scrape_fail)
-      @scrape_fail = scrape_fail
-    end
-    
     def scrape
       raw_page = HTTParty.get(ORIGIN_URL)
       events = []
@@ -21,10 +17,6 @@ module Scraper
       end
       create_events_in_aggregator(events)
     end
-
-    private
-
-    attr_reader :scrape_fail
 
     def create_events_in_aggregator(events)
       events.each { |event| create_event_in_aggregator(event) }

--- a/lib/scraper/five_calls.rb
+++ b/lib/scraper/five_calls.rb
@@ -9,7 +9,7 @@ module Scraper
     CAMPAIGN_ATTRS = [
       'browser_url', 'origin_system', 'title', 'description', 'template', 'action_type'
     ]
-    ACTION_TYPE = 'action_type'
+    ACTION_TYPE = 'phone'
 
     def scrape
       campaigns = []
@@ -28,9 +28,7 @@ module Scraper
       campaign['description'] = issue['reason']
       campaign['template'] = issue['script']
       campaign['targets'] = parse_targets(issue['contacts'])
-          
       campaign['identifiers'] = ["#{ORIGIN_SYSTEM}:#{issue['id']}"]
-      # ^ yes?
       campaign.reject{ |k,v| v.empty? }
     end
 
@@ -79,7 +77,8 @@ module Scraper
     end
 
     def is_department?(text)
-      if text =~ /dep[^"\r\n]*\sof\s"]/i
+      # e.g. "Department of Justice"
+      if text =~ /dep[^"\r\n]*\sof\s"/i
         true
       end
     end
@@ -91,7 +90,6 @@ module Scraper
         full_name_and_organization = data['name'].split(',')
 
         # Sometimes 5Calls pops in a department but no user
-        # e.g. "Department of Justice"
         if is_department?(full_name_and_organization[0])
           target['organization'] = full_name_and_organization[0]
         else

--- a/lib/scraper/five_calls.rb
+++ b/lib/scraper/five_calls.rb
@@ -45,12 +45,7 @@ module Scraper
       # We're doing it here because we always want to ensure the scraper can
       # continue iterating through the list of scraped campaigns.
 
-      scrape_fail.create!(
-        status_code: e.http_code,
-        message: e.message,
-        backtrace: e.backtrace[1..4],
-        scrape_attrs: campaign_data
-      )
+      log_scrape_failure(e, campaign_data)
     end
 
     def find_or_create_campaign(campaign_data)

--- a/lib/scraper/five_calls.rb
+++ b/lib/scraper/five_calls.rb
@@ -1,0 +1,121 @@
+require 'scraper/scraper_base'
+
+require 'pry'
+
+module Scraper
+  class FiveCalls < ScraperBase
+    ORIGIN_SYSTEM = '5Calls'
+    ORIGIN_URL = 'https://5calls.org/issues/'
+    CAMPAIGN_ATTRS = [
+      'browser_url', 'origin_system', 'title', 'description', 'template', 'action_type'
+    ]
+    ACTION_TYPE = 'action_type'
+
+    def scrape
+      campaigns = []
+      issues.each do |issue|
+        campaigns << parse_issue(issue) unless issue['inactive']
+      end
+      create_campaigns_in_aggregator(campaigns)
+    end
+
+    def parse_issue(issue)
+      campaign = Hash.new
+      campaign['action_type'] = ACTION_TYPE
+      campaign['origin_system'] = ORIGIN_SYSTEM
+      campaign['browser_url'] = issue['link'] #might be blank
+      campaign['title'] = issue['name']
+      campaign['description'] = issue['reason']
+      campaign['template'] = issue['script']
+      campaign['targets'] = parse_targets(issue['contacts'])
+          
+      campaign['identifiers'] = ["#{ORIGIN_SYSTEM}:#{issue['id']}"]
+      # ^ yes?
+      campaign.reject{ |k,v| v.empty? }
+    end
+
+    def create_campaigns_in_aggregator(campaigns)
+      campaigns.each { |campaign| create_campaign_in_aggregator(campaign) }
+    end
+
+    def create_campaign_in_aggregator(campaign_data)
+      find_or_create_campaign(campaign_data)
+    rescue Exception => e
+      # Rescuing all exceptions is typically a terrible idea.
+      # We're doing it here because we always want to ensure the scraper can
+      # continue iterating through the list of scraped campaigns.
+
+      scrape_fail.create!(
+        status_code: e.http_code,
+        message: e.message,
+        backtrace: e.backtrace[1..4],
+        scrape_attrs: campaign_data
+      )
+    end
+
+    def find_or_create_campaign(campaign_data)
+      # We're gently slicing stuff, rather than deleting, since deleting
+      # elements from the hash would mutate it and we want the full list of 
+      # attributes in cases where scraping fails and we log those attributes
+
+      campaign_attrs = campaign_data.slice(*CAMPAIGN_ATTRS)
+      targets = find_or_create_targets(campaign_data['targets'])
+
+      CTAAggregatorClient::AdvocacyCampaign.create(campaign_attrs, targets)
+    rescue RestClient::Found => err
+      nil
+    end
+
+    def find_or_create_targets(targets)
+      return unless targets
+      target_ids = targets.map { |target_data| find_or_create_target(target_data) }
+      { targets: target_ids }
+    end
+
+    def find_or_create_target(target_data)
+      response = CTAAggregatorClient::Target.create(target_data)
+      target_id = JSON.parse(response.body)['data']['id']
+      target_id
+    rescue RestClient::Found => err
+      if err.http_headers[:location]
+        target_id = err.http_headers[:location].split('/').last
+        target_id
+      end
+    end
+
+    def is_department?(text)
+      if text =~ /dep[^"\r\n]*\sof\s"]/i
+        true
+      end
+    end
+
+    def parse_targets(target_data = [])
+      target_data.map do |data|
+        target = Hash.new
+
+        full_name_and_organization = data['name'].split(',')
+
+        # Sometimes 5Calls pops in a department but no user
+        # e.g. "Department of Justice"
+        if is_department?(full_name_and_organization[0])
+          target['organization'] = full_name_and_organization[0]
+        else
+          full_name = full_name_and_organization[0].split(' ')
+
+          target['organization'] = full_name_and_organization[1]
+          target['given_name'] = full_name.shift
+          target['family_name'] = full_name
+        end
+
+        target['phone_numbers'] = [ primary: true, number: data['phone'], number_type: :work ]
+        target.reject{ |k,v| v.nil? }
+      end
+    end
+
+    def issues
+      response = RestClient.get(ORIGIN_URL)
+      JSON.parse(response)['issues']
+    end
+  end
+end
+

--- a/lib/scraper/scraper_base.rb
+++ b/lib/scraper/scraper_base.rb
@@ -50,7 +50,7 @@ module Scraper
       raw_page = HTTParty.get(link)
       Nokogiri::HTML(raw_page)
     end
-    
+
     def log_scrape_failure(e, scrape_attrs)
       scrape_fail.create!(
         status_code: e.http_code,

--- a/lib/scraper/scraper_base.rb
+++ b/lib/scraper/scraper_base.rb
@@ -50,5 +50,14 @@ module Scraper
       raw_page = HTTParty.get(link)
       Nokogiri::HTML(raw_page)
     end
+    
+    def log_scrape_failure(e, scrape_attrs)
+      scrape_fail.create!(
+        status_code: e.http_code,
+        message: e.http_body,
+        backtrace: e.backtrace[1..4],
+        scrape_attrs: scrape_attrs
+      )
+    end
   end
 end

--- a/lib/scraper/scraper_base.rb
+++ b/lib/scraper/scraper_base.rb
@@ -6,6 +6,14 @@ require 'cta_aggregator_client'
 module Scraper
   class ScraperBase
 
+    def initialize(scrape_fail)
+      @scrape_fail = scrape_fail
+    end
+
+    private
+
+    attr_reader :scrape_fail
+
     def find_next_node(current_node)
       el = current_node.next_element
 


### PR DESCRIPTION
This PR:

- Adds a Scraper for 5Calls
- Moves shared logic into parent class

Note: there's a corresponding PR for the CTAAggretator API that  permits this scraper to create an advocacy campaign with either a target's organization or a target's name. https://github.com/Ragtagteam/cta-aggregator/pull/53