### PR TITLE
Feature/five calls polishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ this command:
 will scrape everything available on Emily's List.  Failures will be stored in the DB, so that we
 know when scraper scripts need to be updated.
 
+Scraper rake tasks can be found in `lib/tasks/scraper.rake`. To run all the scrapers, the following command.
+```
+rake scape:all
+```
+
 # Admins
 
 There is a rake task for creating an admin. You'll need to pass an email and a password as arguments.

--- a/lib/scraper/emilys_list.rb
+++ b/lib/scraper/emilys_list.rb
@@ -4,10 +4,10 @@ module Scraper
   class EmilysList < ScraperBase
 
     ORIGIN_SYSTEM = "Emily's List"
-    SYSTEM_NAME = "emilys_list"
+    SYSTEM_NAME = "emilys-list"
     ORIGIN_URL = "http://www.emilyslist.org/pages/entry/events"
     EVENT_ATTRS = [
-      'browser_url', 'origin_system', 'title', 'description', 'start_date', 'end_date', 'free', 'featured_image_url'
+      'browser_url', 'origin_system', 'title', 'description', 'start_date', 'end_date', 'free', 'featured_image_url', 'identifiers'
     ].freeze
 
     def scrape

--- a/lib/scraper/five_calls.rb
+++ b/lib/scraper/five_calls.rb
@@ -5,7 +5,7 @@ module Scraper
     ORIGIN_SYSTEM = '5Calls'
     ORIGIN_URL = 'https://5calls.org/issues/'
     CAMPAIGN_ATTRS = [
-      'browser_url', 'origin_system', 'title', 'description', 'template', 'action_type'
+      'browser_url', 'origin_system', 'title', 'description', 'template', 'action_type', 'identifiers'
     ]
     ACTION_TYPE = 'phone'
 

--- a/lib/scraper/five_calls.rb
+++ b/lib/scraper/five_calls.rb
@@ -74,13 +74,6 @@ module Scraper
       end
     end
 
-    def is_department?(text)
-      # e.g. "Department of Justice"
-      if text =~ /dep[^"\r\n]*\sof\s"/i
-        true
-      end
-    end
-
     def parse_targets(target_data = [])
       target_data.map do |data|
         target = Hash.new
@@ -88,19 +81,34 @@ module Scraper
         full_name_and_organization = data['name'].split(',')
 
         # Sometimes 5Calls pops in a department but no user
-        if is_department?(full_name_and_organization[0])
+        if is_department_or_committee?(full_name_and_organization[0])
+
           target['organization'] = full_name_and_organization[0]
         else
           full_name = full_name_and_organization[0].split(' ')
 
           target['organization'] = full_name_and_organization[1]
           target['given_name'] = full_name.shift
-          target['family_name'] = full_name
+          target['family_name'] = full_name[0]
         end
 
         target['phone_numbers'] = [ primary: true, number: data['phone'], number_type: :work ]
         target.reject{ |k,v| v.nil? }
       end
+    end
+
+    def is_committee?(text)
+      # e.g. "Senate Committee on Health Education"
+      text =~ /committee/i
+    end
+
+    def is_department?(text)
+      # e.g. "Department of Justice"
+      text =~ /dep[^"\r\n]*\sof\s"/i
+    end
+
+    def is_department_or_committee?(text)
+      is_department?(text) || is_committee?(text) 
     end
 
     def issues

--- a/lib/tasks/scrape.rake
+++ b/lib/tasks/scrape.rake
@@ -2,8 +2,17 @@ require 'scraper'
 
 namespace :scrape do
 
+  task :all => :environment do
+    Scraper.emilys_list.scrape
+    Scraper.five_calls.scrape
+  end
+
   task :emilys_list => :environment do
     Scraper.emilys_list.scrape
+  end
+
+  task :five_calls => :environment do
+    Scraper.five_calls.scrape
   end
 
 end


### PR DESCRIPTION
I inspected the scraper results and I found a few things that I missed originally.

This PR

- Adds rake task for 5Calls and another for running all the scrapers
- Fix last name parsing (I had been sending a 1 element array, not the thing *in* that array)
- Add logic for determining if the 5Calls issue is targeting a committee (originally it was only discerning between people and departments)
- Include identifiers data when creating events and advocacy campaigns (whoops)
- Hyphenate "Emily's List" (rather than underscore), to match the convention est'd in the API
