### PR TITLE
Feature/scrape fail message type

### DIFF
--- a/app/views/scrape_fails/index.html.erb
+++ b/app/views/scrape_fails/index.html.erb
@@ -52,7 +52,7 @@
       </td>
 
       <td>
-        <%= scrape_fail.message %>
+        <%= scrape_fail.message.values.first %>
       </td>
 
       <td>

--- a/db/migrate/20170816034903_alter_scrape_fail_change_message_type.rb
+++ b/db/migrate/20170816034903_alter_scrape_fail_change_message_type.rb
@@ -1,0 +1,15 @@
+class AlterScrapeFailChangeMessageType < ActiveRecord::Migration[5.1]
+  def up
+    # theoretically the following command changes the datatype from text to jsonb.
+    # change_column :scrape_fails, :messge, :jsonb, using: 'message::JSON', default: {}
+    # However, it's not working, so we're just going to blow away the old column and make a new one the right way
+    # Project hasn't hit prod env yet, so no danger in losing data.
+    remove_column :scrape_fails, :message
+    add_column :scrape_fails, :message, :jsonb, default: {}
+  end
+
+  def down
+    remove_column :scrape_fails, :message
+    add_column :scrape_fails, :message, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170807030919) do
+ActiveRecord::Schema.define(version: 20170816034903) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -34,12 +34,12 @@ ActiveRecord::Schema.define(version: 20170807030919) do
 
   create_table "scrape_fails", force: :cascade do |t|
     t.string "status_code"
-    t.string "message"
     t.text "backtrace", default: [], array: true
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.jsonb "scrape_attrs", default: {}
     t.boolean "active", default: true
+    t.jsonb "message", default: {}
   end
 
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -4,7 +4,13 @@ admin.save
 
 ScrapeFail.create!(
   "status_code"=>"500",
-  "message"=>"500 Internal Server Error",
+  "message"=>
+  {
+    "status": 500,
+    "error": "Internal Server Error",
+    "exception": "#\u003cStandardError: StandardError\u003e",
+    "traces": { "Application Trace": [{ "id": 0, "trace": "app/controllers/v1/advocacy_campaigns_controller.rb:6:in `create'" }] }
+  },
   "backtrace"=>
   ["/Users/goober/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rest-client-2.0.1/lib/restclient/abstract_response.rb:103:in `return!'",
    "/Users/goober/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rest-client-2.0.1/lib/restclient/request.rb:809:in `process_result'",


### PR DESCRIPTION
We had been storing the message data as text.  In this PR, we decide to store it as jsonb, which makes sense since the message from the server will always be JSON.