### PR TITLE
Add scraper for Resistance Calendar

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ gem 'devise', '4.3.0'
 
 gem 'nokogiri', '1.8.0'
 gem 'httparty', '0.15.5'
+gem 'hyperclient', '0.8.6'
 gem 'cta_aggregator_client', '0.4.0'
 gem 'Indirizzo', '0.1.7'
 gem 'will_paginate', '3.1.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,13 +63,31 @@ GEM
       railties (>= 3.2, < 5.2)
     erubi (1.6.1)
     execjs (2.7.0)
+    faraday (0.9.2)
+      multipart-post (>= 1.2, < 3)
+    faraday-digestauth (0.2.1)
+      faraday (~> 0.7)
+      net-http-digest_auth (~> 1.4)
+    faraday_hal_middleware (0.0.1)
+      faraday_middleware (>= 0.9, < 0.10)
+    faraday_middleware (0.9.2)
+      faraday (>= 0.7.4, < 0.10)
     ffi (1.9.18)
+    futuroscope (0.1.11)
     globalid (0.4.0)
       activesupport (>= 4.2.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     httparty (0.15.5)
       multi_xml (>= 0.5.2)
+    hyperclient (0.8.6)
+      faraday (>= 0.9.0)
+      faraday-digestauth
+      faraday_hal_middleware
+      faraday_middleware
+      futuroscope
+      net-http-digest_auth
+      uri_template
     i18n (0.8.6)
     jquery-rails (4.3.1)
       rails-dom-testing (>= 1, < 3)
@@ -90,6 +108,8 @@ GEM
     mini_portile2 (2.2.0)
     minitest (5.10.2)
     multi_xml (0.6.0)
+    multipart-post (2.0.0)
+    net-http-digest_auth (1.4.1)
     netrc (0.11.0)
     nio4r (2.1.0)
     nokogiri (1.8.0)
@@ -198,6 +218,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.4)
+    uri_template (0.7.0)
     warden (1.2.7)
       rack (>= 1.0)
     web-console (3.5.1)
@@ -219,6 +240,7 @@ DEPENDENCIES
   devise (= 4.3.0)
   dotenv-rails (= 2.2.1)
   httparty (= 0.15.5)
+  hyperclient (= 0.8.6)
   jquery-rails
   listen (>= 3.0.5, < 3.2)
   nokogiri (= 1.8.0)
@@ -240,4 +262,4 @@ RUBY VERSION
    ruby 2.4.0p0
 
 BUNDLED WITH
-   1.14.6
+   1.15.4

--- a/lib/scraper.rb
+++ b/lib/scraper.rb
@@ -1,5 +1,6 @@
 require 'scraper/emilys_list'
 require 'scraper/five_calls'
+require 'scraper/resistance_calendar'
 
 module Scraper
   class << self
@@ -10,6 +11,10 @@ module Scraper
 
     def five_calls
       FiveCalls.new(ScrapeFail)
+    end
+    
+    def resistance_calendar
+      ResistanceCalendar.new(ScrapeFail)
     end
   end
 end

--- a/lib/scraper/emilys_list.rb
+++ b/lib/scraper/emilys_list.rb
@@ -20,23 +20,9 @@ module Scraper
       create_events_in_aggregator(events)
     end
 
-    def create_events_in_aggregator(events)
-      events.each { |event| create_event_in_aggregator(event) }
-    end
-
-    def create_event_in_aggregator(event_data)
-      find_or_create_event(event_data)
-    rescue Exception => e
-      # Rescuing all exceptions is typically a terrible idea.
-      # We're doing it here because we always want to ensure the scraper can
-      # continue iterating through the list of scraped events.
-
-      log_scrape_failure(e, event_data)
-    end
-
     def find_or_create_event(event_data)
       # We're gently slicing stuff, rather than deleting, since deleting
-      # elements from the hash would mutate it and we want the full list of 
+      # elements from the hash would mutate it and we want the full list of
       # attributes in cases where scraping fails and we log those attributes
 
       event_attrs = event_data.slice(*EVENT_ATTRS)
@@ -46,17 +32,6 @@ module Scraper
       CTAAggregatorClient::Event.create(event_attrs)
     rescue RestClient::Found => err
       nil
-    end
-
-    def find_or_create_location(location_data)
-      response = CTAAggregatorClient::Location.create(location_data)
-      location_id = JSON.parse(response.body)['data']['id']
-      { location: location_id }
-    rescue RestClient::Found => err
-      if err.http_headers[:location]
-        location_id = err.http_headers[:location].split('/').last
-        { location: location_id }
-      end
     end
 
     def event_urls(raw_page)

--- a/lib/scraper/resistance_calendar.rb
+++ b/lib/scraper/resistance_calendar.rb
@@ -8,9 +8,6 @@ module Scraper
     ORIGIN_SYSTEM = "Resistance Calendar"
     SYSTEM_NAME = "resistance-calendar"
     ORIGIN_URL = "https://resistance-calendar.herokuapp.com/v1/events"
-    EVENT_ATTRS = [
-      'browser_url', 'origin_system', 'title', 'description', 'start_date', 'end_date', 'free', 'featured_image_url', 'identifiers'
-    ].freeze
     
     def scrape
       osdi = Hyperclient.new(ORIGIN_URL)

--- a/lib/scraper/resistance_calendar.rb
+++ b/lib/scraper/resistance_calendar.rb
@@ -1,0 +1,36 @@
+require 'scraper/scraper_base'
+require 'hyperclient'
+require 'cta_aggregator_client'
+
+module Scraper
+  class ResistanceCalendar < ScraperBase
+
+    ORIGIN_SYSTEM = "Resistance Calendar"
+    SYSTEM_NAME = "resistance-calendar"
+    ORIGIN_URL = "https://resistance-calendar.herokuapp.com/v1/events"
+    EVENT_ATTRS = [
+      'browser_url', 'origin_system', 'title', 'description', 'start_date', 'end_date', 'free', 'featured_image_url', 'identifiers'
+    ].freeze
+    
+    def scrape
+      osdi = Hyperclient.new(ORIGIN_URL)
+      create_events_in_aggregator( osdi['osdi:events'] )
+    end
+    
+    # this needs to be here, and not in scraper_base, because we can only use a subset of the location data from resistance cal
+    def find_or_create_event(event_data)
+      event_attrs = event_data._attributes.to_h.slice(*EVENT_ATTRS)
+      
+      if ed = event_data['location']
+        location_hash = {address_lines: ed['address_lines'], locality: ed['locality'], region: ed['region'], postal_code: ed['postal_code'], venue: ed['venue']}
+        location = find_or_create_location( location_hash )   
+        event_attrs.merge!(location) 
+      end
+      response = CTAAggregatorClient::Event.create(event_attrs)
+
+    rescue RestClient::Found => err
+      nil
+    end
+    
+  end
+end

--- a/lib/tasks/scrape.rake
+++ b/lib/tasks/scrape.rake
@@ -14,5 +14,10 @@ namespace :scrape do
   task :five_calls => :environment do
     Scraper.five_calls.scrape
   end
+  
+  # bundle exec rake scrape:resistance_calendar  --trace
+  task :resistance_calendar => :environment do
+    Scraper.resistance_calendar.scrape
+  end
 
 end

--- a/lib/tasks/scrape.rake
+++ b/lib/tasks/scrape.rake
@@ -5,6 +5,7 @@ namespace :scrape do
   task :all => :environment do
     Scraper.emilys_list.scrape
     Scraper.five_calls.scrape
+    Scraper.resistance_calendar.scrape
   end
 
   task :emilys_list => :environment do
@@ -15,7 +16,6 @@ namespace :scrape do
     Scraper.five_calls.scrape
   end
   
-  # bundle exec rake scrape:resistance_calendar  --trace
   task :resistance_calendar => :environment do
     Scraper.resistance_calendar.scrape
   end


### PR DESCRIPTION
Moved some common methods to scraper_base. Many Resistance Cal events don't have locations or a 'free' entry, so had to modify cta-aggregator to handle that.

This doesn't yet support pagination, will add that in separate PR once this is accepted.