### PR TITLE
silencing emily's list scraper

### DIFF
--- a/lib/tasks/scrape.rake
+++ b/lib/tasks/scrape.rake
@@ -3,7 +3,8 @@ require 'scraper'
 namespace :scrape do
 
   task :all => :environment do
-    Scraper.emilys_list.scrape
+    # Silencing Emily's list b/c very few CTAs and HTML shifts a lot
+    # Scraper.emilys_list.scrape
     Scraper.five_calls.scrape
     Scraper.resistance_calendar.scrape
   end


### PR DESCRIPTION
This PR stops the Emily's List scraper from running and leaves a note explaining why we turned it off.